### PR TITLE
Move contents of dir when dir already exists in the destination

### DIFF
--- a/src/GenesisCopyWindow.h
+++ b/src/GenesisCopyWindow.h
@@ -53,6 +53,8 @@ class GenesisCopyWindow : public BWindow
 //		BCheckBox		*m_MoreCB;
 
 		int				m_FileCount;
+		int				m_TopFilesLeft;
+		int				m_CurrentLevel;
 		int32			m_Selection;
 
 		thread_id		m_CopyThread;

--- a/src/GenesisCopyWindow.h
+++ b/src/GenesisCopyWindow.h
@@ -64,6 +64,7 @@ class GenesisCopyWindow : public BWindow
 		bool			m_Paused;
 		bool			m_SkipAllCopyError;
 		bool 			m_OverwriteAll;
+		bool 			m_CopyAll;
 		bool			m_SkipSymLinkCreationError;
 
 		void			Go(void);

--- a/src/GenesisMoveWindow.h
+++ b/src/GenesisMoveWindow.h
@@ -50,6 +50,8 @@ class GenesisMoveWindow : public BWindow
 		PanelView		*m_DestPanel;
 
 		int				m_FileCount;
+		int				m_TopFilesLeft;
+		int				m_CurrentLevel;
 		int32			m_Selection;
 
 		thread_id		m_MoveThread;

--- a/src/GenesisMoveWindow.h
+++ b/src/GenesisMoveWindow.h
@@ -61,6 +61,7 @@ class GenesisMoveWindow : public BWindow
 		bool			m_Paused;
 		bool			m_SkipAllMoveError;
 		bool 			m_OverwriteAll;
+		bool 			m_MoveAll;
 		bool			m_SkipSymLinkCreationError;
 		bool			m_SkipAllMissing;		// move
 


### PR DESCRIPTION
 FIX #47 + added alerts when user is trying to overwrite directory with file and vice versa
